### PR TITLE
Mtbls 785 feb editor changes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -23,6 +23,7 @@ import { MetaComponent } from "./components/guide/meta/meta.component";
 import { GuidedAssaysComponent } from "./components/guide/assays/assays.component";
 import { GuidesComponent } from "./components/public/guides/guides.component";
 import { NoStudyPageComponent } from "./components/shared/errors/no-study-page/no-study-page.component";
+import { StudyNotPublicComponent } from "./components/shared/errors/study-not-public/study-not-public.component";
 
 /* eslint-disable prefer-arrow/prefer-arrow-functions */
 export function reviewerStudyMatcher(url: UrlSegment[]): UrlMatchResult {
@@ -117,6 +118,7 @@ const routes: Routes = [
   },
   { path: "study", redirectTo: "console", pathMatch: "full" },
   { path: "study-not-found", component: NoStudyPageComponent },
+  { path: "study-not-public", component: StudyNotPublicComponent},
   { path: "page-not-found", component: PageNotFoundComponent },
   { matcher: publicStudyMatcher, canActivate: [AuthGuard], component: PublicStudyComponent },
   { matcher: reviewerStudyMatcher, canActivate: [AuthGuard], component: PublicStudyComponent },

--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -6,11 +6,10 @@ import { SessionStatus } from "./models/mtbl/mtbls/enums/session-status.enum";
 import { ConfigurationService } from "./configuration.service";
 
 import jwtDecode from "jwt-decode";
-import { httpOptions, MtblsJwtPayload } from "./services/headers";
+import { MtblsJwtPayload } from "./services/headers";
 import { HttpClient } from "@angular/common/http";
 
 import { ErrorMessageService } from "./services/error-message.service";
-import { environment } from "src/environments/environment";
 import { Store } from "@ngxs/store";
 import { StudyPermissionNS } from "./ngxs-store/non-study/application/application.actions";
 @Injectable({
@@ -20,11 +19,8 @@ export class AuthGuard  implements OnInit {
 
   constructor(
     private editorService: EditorService,
-    private configService: ConfigurationService,
     private router: Router,
     private route: ActivatedRoute,
-    private http: HttpClient,
-    private errorMessageService: ErrorMessageService,
     private store: Store
   ) { }
 
@@ -102,7 +98,7 @@ export class AuthGuard  implements OnInit {
         if (currentUser !== userName) {
           this.editorService.clearSessionData();
           await this.editorService.loginWithJwt(jwt, userName);
-          toastr.info("User: " + userName, "Session is swithed to other user.", {
+          toastr.info("User: " + userName, "Session is switched to other user.", {
             timeOut: "5000",
             positionClass: "toast-top-center",
             preventDuplicates: true,

--- a/src/app/auth-guard.service.ts
+++ b/src/app/auth-guard.service.ts
@@ -3,13 +3,10 @@ import * as toastr from "toastr";
 import { Router, ActivatedRouteSnapshot, RouterStateSnapshot, ActivatedRoute } from "@angular/router";
 import { EditorService } from "./services/editor.service";
 import { SessionStatus } from "./models/mtbl/mtbls/enums/session-status.enum";
-import { ConfigurationService } from "./configuration.service";
 
 import jwtDecode from "jwt-decode";
 import { MtblsJwtPayload } from "./services/headers";
-import { HttpClient } from "@angular/common/http";
 
-import { ErrorMessageService } from "./services/error-message.service";
 import { Store } from "@ngxs/store";
 import { StudyPermissionNS } from "./ngxs-store/non-study/application/application.actions";
 @Injectable({
@@ -42,14 +39,11 @@ export class AuthGuard  implements OnInit {
 
   // this will either redirect, or return false to indicate its not a private MTBLS request
   async privateMTBLSHandler(url: string, state: RouterStateSnapshot) {
-    console.log('if this log is not found we have a problem')
     if (url.startsWith("/MTBLS")) {
-      console.log('are we starting the privateMTBLSHandler method?')
       const studyIdentifier = url.split("/")[1];
       const regEx = new RegExp('^(MTBLS[1-9][0-9]{0,10})($|\\?)', 'g');
       const studyIdResults = studyIdentifier.match(regEx);
       if (studyIdResults === null || studyIdResults.length === 0) {
-        console.log('uh oh')
         this.editorService.redirectUrl = url;
         const errorCode = "E-0001-003";
         this.router.navigate(["/study-not-found"], { queryParams: { code: errorCode } });
@@ -57,11 +51,8 @@ export class AuthGuard  implements OnInit {
       }
       const studyPermission = await this.editorService.getStudyPermissionByStudyId(studyIdentifier);
       if (studyPermission.studyId === studyIdentifier) {
-        console.log('hitting study not public router call');
-        console.trace();
         this.editorService.redirectUrl = url;
         this.router.navigate(["/study-not-public"]);
-        //return false;
       }
 
 
@@ -74,7 +65,6 @@ export class AuthGuard  implements OnInit {
     try {
       let loginOneTimeToken = null;
       if (state.root.queryParamMap.has("loginOneTimeToken") === false) {
-        console.log('first if clause in auth guard');
         const __ = this.privateMTBLSHandler(state.url, state);
         return true;
       }
@@ -175,7 +165,6 @@ export class AuthGuard  implements OnInit {
    * @returns boolean indicating whether the user is logged in.
    */
   async checkUrlAndLogin(url: string, state: RouterStateSnapshot) {
-    console.log(`${state.url}`)
     const localJwt = localStorage.getItem("jwt");
     if (url.startsWith("/login")) {
       if (localJwt !== null) {
@@ -208,9 +197,6 @@ export class AuthGuard  implements OnInit {
       return await this.checkStudyUrl(url, studyIdentifier, state);
     } else if (obfuscationCode !== null) {
       return await this.checkStudyObfuscationCode(url, obfuscationCode, state, null);
-    }
-    if (url === '/study/MTBLS9058') {
-      console.log('getting to this point without redirection')
     }
     switch (this.evaluateSession(null)) {
       case SessionStatus.Active:
@@ -319,7 +305,6 @@ export class AuthGuard  implements OnInit {
 
       this.editorService.redirectUrl = url;
       const errorCode = "E-0001-004";
-      console.log("we don't actualy want to be getting here")
       //this.router.navigate(["/study-not-found"], { queryParams: { code: errorCode } });
       const __ = this.privateMTBLSHandler(url, state);
       return false;
@@ -335,7 +320,6 @@ export class AuthGuard  implements OnInit {
           return false;
         }
         if (studyPermission.userName == null || studyPermission.userName.length === 0) {
-          console.log('finally getting here')
           const __ = this.privateMTBLSHandler(url, state);
           this.editorService.redirectUrl = url;
           this.router.navigate(["/login"]);

--- a/src/app/components/shared/design-descriptors/design-descriptors.component.html
+++ b/src/app/components/shared/design-descriptors/design-descriptors.component.html
@@ -16,6 +16,8 @@
       <span>
         <p class="is-pulled-left">
           Design Descriptors (Keywords)
+          <span *ngIf="!isReadOnly"><mat-icon [matTooltip]="'Design Descriptors are the keywords you would use to describe the study'" >help</mat-icon></span>
+
         </p>
         <mtbls-design-descriptor
           *ngIf="!isReadOnly"

--- a/src/app/components/shared/errors/study-not-public/study-not-public.component.css
+++ b/src/app/components/shared/errors/study-not-public/study-not-public.component.css
@@ -1,0 +1,37 @@
+.is-rounded {
+    border-radius: 4px !important;
+  }
+  
+  .message-header {
+    font-size: large;
+    align-items: center;
+    background-color: #eef6fc;
+    border-radius: 0;
+    color: #174287;
+    display: flex;
+    font-weight: 700;
+    justify-content: space-between;
+    line-height: 1.25;
+    padding: 0.75em 1em;
+    position: relative;
+  }
+  
+  .message-body {
+    border-color: blue;
+    border-radius: 0px;
+    border-style: solid;
+    border-width: 0;
+    color: #4a4a4a;
+    padding: 1.25em 1.5em;
+  }
+  
+  .message {
+    font-size: large;
+    background-color: #ffffffb5;
+    border-radius: 0px;
+    border: 1px solid #cce9ff;
+  }
+  
+  .ml {
+    margin-left: 4%;
+  }

--- a/src/app/components/shared/errors/study-not-public/study-not-public.component.html
+++ b/src/app/components/shared/errors/study-not-public/study-not-public.component.html
@@ -1,0 +1,52 @@
+<div class="columns" style="min-height: 100vh; margin: 60px 0">
+    <div class="column is-8 is-offset-2">
+      <div style="margin: 0 0 20px 0">
+        <article class="message is-small has-shadow">
+          <div (click)="toggleMessage()" class="message-header">
+            <p>
+              <span class="material-icons">error</span>&nbsp;{{ study }} is not public.
+            </p>
+            <button
+              *ngIf="!messageExpanded"
+              style="background-color: transparent; border: 0"
+            >
+              <span class="material-icons">keyboard_arrow_down</span>
+            </button>
+            <button
+              *ngIf="messageExpanded"
+              style="background-color: transparent; border: 0"
+            >
+              <span class="material-icons">keyboard_arrow_up</span>
+            </button>
+          </div>
+          <div  class="message-body">
+            <div class="container">
+                
+                <p>The MetaboLights study <strong>{{ study }}</strong> has been accessioned but not yet publicly released.</p>
+                <br>
+                <b>If you are a reviewer of a manuscript that includes this dataset:</b>
+                <br>
+                <ul class="ml">
+                    <li>You should also have received a private reviewer link to access this dataset <strong>{{study}}</strong>.</li>
+                    <li>If you did not, contact the journal editor about obtaining this information.</li>
+                    <li>If you did, go directly to the private reviewer link to access the data.</li>
+                </ul>
+                <br>
+                <b>If you have seen this identifier in an accepted manuscript:</b>
+                <br>
+                <ul class="ml">
+                    <li>Then this dataset should be publicly released. Probably the submitter(s) and/or journal have not contacted MetaboLights yet in order to trigger the public release.</li>
+                    <li>Please contact the MetaboLights team at <span class="email">metabolights-help&#64;ebi.ac.uk</span> to request that the dataset be associated with the article and released.</li>
+                </ul>
+                <br>
+                <b>If you are just waiting for this dataset to be released:</b>
+                <ul class="ml">
+                    <li>It is not available at this time.</li>
+                    <li>Please check again later or contact the submitter(s) or MetaboLights team to see when it will be public.</li>
+                </ul>
+            </div>
+          </div>
+        </article>
+      </div>
+  </div>
+  

--- a/src/app/components/shared/errors/study-not-public/study-not-public.component.spec.ts
+++ b/src/app/components/shared/errors/study-not-public/study-not-public.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StudyNotPublicComponent } from './study-not-public.component';
+
+describe('StudyNotPublicComponent', () => {
+  let component: StudyNotPublicComponent;
+  let fixture: ComponentFixture<StudyNotPublicComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StudyNotPublicComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(StudyNotPublicComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/shared/errors/study-not-public/study-not-public.component.ts
+++ b/src/app/components/shared/errors/study-not-public/study-not-public.component.ts
@@ -13,42 +13,29 @@ import { ErrorMessageService } from 'src/app/services/error-message.service';
   styleUrl: './study-not-public.component.css'
 })
 export class StudyNotPublicComponent implements OnInit {
-  messageHeader = "Study page not found";
-  messageContent = "Error while loading study. Possible reasons: 1) Study accesion number is not valid or it is not public or editable.";
-  messageExpanded = true;
   study: string = ""
   constructor(
     private store: Store,
     private route: ActivatedRoute,
     private router: Router,
-    private errorMessageService: ErrorMessageService,
     private editorService: EditorService
 ) {}
-  toggleMessage() {
-    this.messageExpanded = !this.messageExpanded;
-  }
+
   ngOnInit() {
     
     this.store.dispatch(new Loading.Disable())
      
       this.route.queryParams.subscribe((params) => {
-        const errorCode = params.code ?? "";
 
-        //const message = this.errorMessageService.getErrorMessage(errorCode);
-       // const header = message?.header ?? "Study page not found";
-        //const content = message?.content ?? "Error while loading study.";
         const url = this.editorService.redirectUrl ?? "";
-        //console.dir(this.route);
         if (url !== "" ) {
           const path = url.split("?")[0].replace("/", "");
           if(!path.includes('MTBLS')) {
-            console.log('routing to login from study not public component: }' + path)
             this.router.navigate(['login']); 
           } //safeguard in case we somehow arrived here by some manual way
           this.study = path;
         } else {
         }
-        this.messageHeader = "";
       });
   }
 

--- a/src/app/components/shared/errors/study-not-public/study-not-public.component.ts
+++ b/src/app/components/shared/errors/study-not-public/study-not-public.component.ts
@@ -1,0 +1,55 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Store } from '@ngxs/store';
+import { Loading } from 'src/app/ngxs-store/non-study/transitions/transitions.actions';
+import { EditorService } from 'src/app/services/editor.service';
+import { ErrorMessageService } from 'src/app/services/error-message.service';
+
+@Component({
+  selector: 'app-study-not-public',
+  standalone: true,
+  imports: [],
+  templateUrl: './study-not-public.component.html',
+  styleUrl: './study-not-public.component.css'
+})
+export class StudyNotPublicComponent implements OnInit {
+  messageHeader = "Study page not found";
+  messageContent = "Error while loading study. Possible reasons: 1) Study accesion number is not valid or it is not public or editable.";
+  messageExpanded = true;
+  study: string = ""
+  constructor(
+    private store: Store,
+    private route: ActivatedRoute,
+    private router: Router,
+    private errorMessageService: ErrorMessageService,
+    private editorService: EditorService
+) {}
+  toggleMessage() {
+    this.messageExpanded = !this.messageExpanded;
+  }
+  ngOnInit() {
+    
+    this.store.dispatch(new Loading.Disable())
+     
+      this.route.queryParams.subscribe((params) => {
+        const errorCode = params.code ?? "";
+
+        //const message = this.errorMessageService.getErrorMessage(errorCode);
+       // const header = message?.header ?? "Study page not found";
+        //const content = message?.content ?? "Error while loading study.";
+        const url = this.editorService.redirectUrl ?? "";
+        //console.dir(this.route);
+        if (url !== "" ) {
+          const path = url.split("?")[0].replace("/", "");
+          if(!path.includes('MTBLS')) {
+            console.log('routing to login from study not public component: }' + path)
+            this.router.navigate(['login']); 
+          } //safeguard in case we somehow arrived here by some manual way
+          this.study = path;
+        } else {
+        }
+        this.messageHeader = "";
+      });
+  }
+
+}

--- a/src/app/components/shared/messages/prompt-refresh/prompt-refresh.component.html
+++ b/src/app/components/shared/messages/prompt-refresh/prompt-refresh.component.html
@@ -1,0 +1,4 @@
+<div class="notification is-warning">
+    <mat-icon>info</mat-icon> If you are not seeing the expected changes to your {{context}} section, try refreshing the page.
+  </div>
+  <br>

--- a/src/app/components/shared/messages/prompt-refresh/prompt-refresh.component.spec.ts
+++ b/src/app/components/shared/messages/prompt-refresh/prompt-refresh.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { By } from '@angular/platform-browser';
 import { PromptRefreshComponent } from './prompt-refresh.component';
 
 describe('PromptRefreshComponent', () => {
@@ -9,15 +9,38 @@ describe('PromptRefreshComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PromptRefreshComponent]
-    })
-    .compileComponents();
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PromptRefreshComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should render the default message without context', () => {
+    fixture.detectChanges();
+    const messageElement = fixture.debugElement.query(By.css('.notification')).nativeElement;
+    expect(messageElement.textContent).toContain('If you are not seeing the expected changes to your  section, try refreshing the page.');
+  });
+
+  it('should display the provided context in the message', () => {
+    component.context = 'protocols';
+    fixture.detectChanges();
+    const messageElement = fixture.debugElement.query(By.css('.notification')).nativeElement;
+    expect(messageElement.textContent).toContain('If you are not seeing the expected changes to your protocols section, try refreshing the page.');
+  });
+
+  it('should display the info icon', () => {
+    fixture.detectChanges();
+    const iconElement = fixture.debugElement.query(By.css('mat-icon')).nativeElement;
+    expect(iconElement.textContent).toContain('info');
+  });
+
+  it('should apply the correct CSS class to the notification', () => {
+    fixture.detectChanges();
+    const notificationElement = fixture.debugElement.query(By.css('.notification.is-warning'));
+    expect(notificationElement).toBeTruthy();
   });
 });

--- a/src/app/components/shared/messages/prompt-refresh/prompt-refresh.component.spec.ts
+++ b/src/app/components/shared/messages/prompt-refresh/prompt-refresh.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PromptRefreshComponent } from './prompt-refresh.component';
+
+describe('PromptRefreshComponent', () => {
+  let component: PromptRefreshComponent;
+  let fixture: ComponentFixture<PromptRefreshComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PromptRefreshComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PromptRefreshComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/shared/messages/prompt-refresh/prompt-refresh.component.ts
+++ b/src/app/components/shared/messages/prompt-refresh/prompt-refresh.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-prompt-refresh',
+  standalone: true,
+  imports: [MatIconModule],
+  templateUrl: './prompt-refresh.component.html',
+  styleUrl: './prompt-refresh.component.css'
+})
+export class PromptRefreshComponent {
+  @Input("context") context: string;
+}

--- a/src/app/components/shared/shared.module.ts
+++ b/src/app/components/shared/shared.module.ts
@@ -58,6 +58,7 @@ import { AsyncStatusTransformPipe } from "./async-task/async-task-status-transfo
 import { BrowserModule } from "@angular/platform-browser";
 import { PaginatedTableComponent } from "./paginated-table/paginated-table.component";
 import { TableComponent } from "./table/table.component";
+import { PromptRefreshComponent } from "./messages/prompt-refresh/prompt-refresh.component";
 
 /**
  * TODO: break this shared module out so that it doesnt become bloated. One lot of components
@@ -96,7 +97,7 @@ import { TableComponent } from "./table/table.component";
     EditTableDirective,
     NoStudyPageComponent,
     AsyncTaskComponent,
-    AsyncStatusTransformPipe
+    AsyncStatusTransformPipe,
   ],
   imports: [
     CommonModule,
@@ -119,6 +120,7 @@ import { TableComponent } from "./table/table.component";
     MatExpansionModule,
     MatTooltipModule,
     QuillModule,
+    PromptRefreshComponent
   ],
   exports: [
     AddAssayComponent,

--- a/src/app/components/shared/table/table.component.ts
+++ b/src/app/components/shared/table/table.component.ts
@@ -12,6 +12,8 @@ import {
   OnChanges,
   inject,
   HostListener,
+  computed,
+  effect,
 } from "@angular/core";
 import { MatPaginator } from "@angular/material/paginator";
 import { MatSort } from "@angular/material/sort";
@@ -36,6 +38,7 @@ import { Assay } from "src/app/ngxs-store/study/assay/assay.actions";
 import { MAF } from "src/app/ngxs-store/study/maf/maf.actions";
 import { AssaysService } from "src/app/services/decomposed/assays.service";
 import { GeneralMetadataState } from "src/app/ngxs-store/study/general-metadata/general-metadata.state";
+import { TransitionsState } from "src/app/ngxs-store/non-study/transitions/transitions.state";
 
 /* eslint-disable @typescript-eslint/dot-notation */
 @Component({
@@ -64,6 +67,8 @@ export class TableComponent implements OnInit, AfterViewChecked, OnChanges {
   readonly$: Observable<boolean> = inject(Store).select(ApplicationState.readonly);
   toastrSettings$: Observable<Record<string, any>> = inject(Store).select(ApplicationState.toastrSettings);
   studyIdentifier$: Observable<string> = inject(Store).select(GeneralMetadataState.id);
+
+
 
   @Input("fileTypes") fileTypes: any = [
     {
@@ -134,6 +139,9 @@ export class TableComponent implements OnInit, AfterViewChecked, OnChanges {
   ontologies = [];
   hit = false;
   baseHref: string;
+
+  actionStack: string[] = [];
+
   constructor(
     private clipboardService: ClipboardService,
     private fb: UntypedFormBuilder,
@@ -146,13 +154,14 @@ export class TableComponent implements OnInit, AfterViewChecked, OnChanges {
 
   ngOnInit() {
     this.setUpSubscriptionsNgxs();
+    //console.log(this.validationsId);
     if (localStorage.getItem(this.data.file) !== null) {
       this.view = localStorage.getItem(this.data.file);
       if (this.view === "expanded") {
         this.displayedTableColumns = Object.keys(this.data.header);
       }
     } else {
-      localStorage.setItem(this.data.file, 'compact')
+      localStorage.setItem(this.data.file, 'compact');
     }
   }
 
@@ -177,6 +186,9 @@ export class TableComponent implements OnInit, AfterViewChecked, OnChanges {
         this.isReadOnly = value;
       }
     });
+
+
+
   }
 
   @HostListener('window:keydown', ['$event'])

--- a/src/app/components/study/factors/factors.component.html
+++ b/src/app/components/study/factors/factors.component.html
@@ -1,7 +1,9 @@
 <div class="card">
   <header class="card-heading" >
     <span>
-      <p class="is-pulled-left">Factors</p>
+      <p class="is-pulled-left">Factors 
+        <span *ngIf="!isReadOnly"><mat-icon [matTooltip]="'Factors are key parameters within a study that differentiate samples into groups'" >help</mat-icon></span>
+      </p>
       <span *ngIf="!isReadOnly">
         <mtbls-factor [value]="null"></mtbls-factor>
       </span>

--- a/src/app/components/study/protocols/protocols.component.html
+++ b/src/app/components/study/protocols/protocols.component.html
@@ -29,7 +29,8 @@
       </h6>
     </div>
   </div>
-
+  <app-prompt-refresh *ngIf="!isStudyReadOnly && actionStack.length > 0" [context]="'protocols'"></app-prompt-refresh>
+  
   <div *ngFor="let protocol of defaultProtocols">
     <span *ngIf="getProtocol(protocol) != null">
       <mtbls-protocol

--- a/src/app/components/study/protocols/protocols.component.ts
+++ b/src/app/components/study/protocols/protocols.component.ts
@@ -5,6 +5,8 @@ import {
   OnChanges,
   SimpleChanges,
   inject,
+  computed,
+  effect,
 } from "@angular/core";
 import { EditorService } from "../../../services/editor.service";
 import { Store } from "@ngxs/store";
@@ -14,6 +16,7 @@ import { Observable } from "rxjs";
 import { ProtocolsState } from "src/app/ngxs-store/study/protocols/protocols.state";
 import { MTBLSProtocol } from "src/app/models/mtbl/mtbls/mtbls-protocol";
 import { SetProtocolExpand } from "src/app/ngxs-store/non-study/application/application.actions";
+import { TransitionsState } from "src/app/ngxs-store/non-study/transitions/transitions.state";
 
 @Component({
   selector: "mtbls-protocols",
@@ -29,6 +32,12 @@ export class ProtocolsComponent implements OnInit, OnChanges {
   studyProtocols$: Observable<MTBLSProtocol[]> = inject(Store).select(ProtocolsState.protocols);
   protocolGuides$: Observable<Record<string, any>> = inject(Store).select(ProtocolsState.protocolGuides);
 
+  actionStackFn = inject(Store).selectSignal(TransitionsState.actionStack);
+  actionStack$ = computed(() => {
+    const filterFn = this.actionStackFn();
+    return filterFn('[protocols]')
+  });
+  
   isStudyReadOnly = false;
 
   validations: any;
@@ -38,7 +47,9 @@ export class ProtocolsComponent implements OnInit, OnChanges {
   customProtocols: string[] = [];
   defaultProtocols: string[] = [];
 
-  protocolGuides = {}
+  protocolGuides = {};
+
+  actionStack: string[] = [];
 
   validationsId = "protocols";
   expand = true;
@@ -94,7 +105,12 @@ export class ProtocolsComponent implements OnInit, OnChanges {
     this.protocolGuides$.subscribe((value) => {
       this.protocolGuides = value;
       console.debug(value);
-    })
+    });
+
+    effect(() => {
+      this.actionStack = this.actionStack$();
+    });
+    
   }
 
   ngOnInit() {}

--- a/src/app/components/study/samples/samples.component.html
+++ b/src/app/components/study/samples/samples.component.html
@@ -66,6 +66,8 @@
     <mat-icon>add</mat-icon> Samples
   </a>
 </span>
+<app-prompt-refresh *ngIf="!isReadOnly && actionStack.length > 0" [context]="'samples'"></app-prompt-refresh>
+
 <mtbls-table
   [fileTypes]="fileTypes"
   (updated)="refresh()"

--- a/src/app/components/study/samples/samples.component.ts
+++ b/src/app/components/study/samples/samples.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, ViewChildren, QueryList, inject } from "@angular/core";
+import { Component, ViewChild, ViewChildren, QueryList, inject, computed, effect } from "@angular/core";
 import { EditorService } from "../../../services/editor.service";
 import { UntypedFormBuilder, UntypedFormGroup } from "@angular/forms";
 import { MTBLSFactor } from "./../../../models/mtbl/mtbls/mtbls-factor";
@@ -18,6 +18,7 @@ import { ValidationState } from "src/app/ngxs-store/study/validation/validation.
 import { DescriptorsState } from "src/app/ngxs-store/study/descriptors/descriptors.state";
 import { GeneralMetadataState } from "src/app/ngxs-store/study/general-metadata/general-metadata.state";
 import { FilesLists } from "src/app/ngxs-store/study/files/files.actions";
+import { TransitionsState } from "src/app/ngxs-store/non-study/transitions/transitions.state";
 
 @Component({
   selector: "mtbls-samples",
@@ -34,6 +35,12 @@ export class SamplesComponent  {
   studyFactors$: Observable<MTBLSFactor[]> = inject(Store).select(DescriptorsState.studyFactors);
 
   studyIdentifier$: Observable<string> = inject(Store).select(GeneralMetadataState.id);
+
+    actionStackFn = inject(Store).selectSignal(TransitionsState.actionStack);
+  actionStack$ = computed(() => {
+    const filterFn = this.actionStackFn();
+    return filterFn('[samples]')
+  });
 
   @ViewChild(TableComponent, { static: true }) sampleTable: TableComponent;
   @ViewChildren(OntologyComponent)
@@ -72,6 +79,8 @@ export class SamplesComponent  {
   form: UntypedFormGroup;
 
   validationsId = "samples";
+
+  actionStack: string[] = [];
 
 
   constructor(private editorService: EditorService, private fb: UntypedFormBuilder, private store: Store) {
@@ -118,6 +127,11 @@ export class SamplesComponent  {
     });
     this.rawFiles$.pipe(filter(val => val !== null)).subscribe((val) => {
       this.rawFileNames = val.filter(file => file.type == 'raw').map(file => file.file.split(".")[0]);
+    });
+
+    effect(() => {
+      this.actionStack = this.actionStack$();
+      console.log(this.actionStack);
     });
   }
 

--- a/src/app/components/study/study.module.ts
+++ b/src/app/components/study/study.module.ts
@@ -73,6 +73,7 @@ import { ListOverridesComponent } from "./validations-v2/modals/list-overrides-m
 import {MatDialogModule} from '@angular/material/dialog';
 import { DeleteOverrideDialogComponent } from "./validations-v2/modals/delete-override-dialog/delete-override-dialog.component";
 import { IsoDateAdapter } from "src/app/adapters/ISO8601.adapter";
+import { PromptRefreshComponent } from "../shared/messages/prompt-refresh/prompt-refresh.component";
 
 
 @NgModule({
@@ -148,7 +149,8 @@ import { IsoDateAdapter } from "src/app/adapters/ISO8601.adapter";
     AddSpaceBeforeCapitalPipe,
     HandleUnderscoreInReportPipe,
     RemoveBackslashesPipe,
-    ValidationDateFormatPipe
+    ValidationDateFormatPipe,
+    PromptRefreshComponent
 
   ],
   exports: [

--- a/src/app/ngxs-store/non-study/transitions/transitions.actions.ts
+++ b/src/app/ngxs-store/non-study/transitions/transitions.actions.ts
@@ -21,3 +21,13 @@ export class SetTabIndex {
     static readonly type = '[transitions] Set Tab Index';
     constructor(public index: string) {}
 }
+
+export namespace IntermittentRefreshActionStack {
+
+    export class Sync {
+        static readonly type = '[transitions] Sync Intermittent Refresh Action Stack'
+        constructor(public actionStack: string[]) {}
+    }
+}
+
+

--- a/src/app/ngxs-store/non-study/transitions/transitions.state.ts
+++ b/src/app/ngxs-store/non-study/transitions/transitions.state.ts
@@ -1,12 +1,13 @@
 import { Injectable } from "@angular/core";
-import { Action, Selector, State, StateContext, StateToken } from "@ngxs/store";
-import { Loading, SetLoadingInfo, SetTabIndex } from "./transitions.actions";
+import { Action, Selector, State, StateContext } from "@ngxs/store";
+import { IntermittentRefreshActionStack, Loading, SetLoadingInfo, SetTabIndex } from "./transitions.actions";
 
 
 export interface TransitionStateModel {
     loading: boolean,
     loadingInformation: string,
-    currentTabIndex: string
+    currentTabIndex: string,
+    intermittentRefreshActionStack: string[]
 }
 
 @State<TransitionStateModel>({
@@ -14,7 +15,8 @@ export interface TransitionStateModel {
     defaults: {
         loading: true,
         loadingInformation: "",
-        currentTabIndex: "0"
+        currentTabIndex: "0",
+        intermittentRefreshActionStack: []
     }
 })
 @Injectable()
@@ -65,6 +67,23 @@ export class TransitionsState {
         })
     }
 
+    @Action(IntermittentRefreshActionStack.Sync)
+    sync(
+        {patchState}: StateContext<TransitionStateModel>, 
+        {actionStack}: IntermittentRefreshActionStack.Sync
+    ) {
+        patchState({
+            intermittentRefreshActionStack: actionStack
+        });
+    }
+
+    @Selector()
+    static actionStack(state: TransitionStateModel) {
+       return (stateContainer: string) => {
+        return state.intermittentRefreshActionStack.filter(action => action.includes(stateContainer));
+       }
+    }
+
     @Selector()
     static loading(state: TransitionStateModel): boolean {
         return state.loading
@@ -80,3 +99,4 @@ export class TransitionsState {
         return state.currentTabIndex
     }
 }
+

--- a/src/app/ngxs-store/study-update-action-interceptor.service.ts
+++ b/src/app/ngxs-store/study-update-action-interceptor.service.ts
@@ -7,6 +7,7 @@ import { MAF } from './study/maf/maf.actions';
 import { Protocols } from './study/protocols/protocols.actions';
 import { Samples } from './study/samples/samples.actions';
 import { SetValidationRunNeeded } from './study/validation/validation.actions';
+import { IntermittentRefreshActionStack } from './non-study/transitions/transitions.actions';
 
 @Injectable({ providedIn: 'root' })
 export class LoggingMiddleware implements NgxsPlugin {
@@ -24,8 +25,26 @@ export class LoggingMiddleware implements NgxsPlugin {
         Protocols,
         Samples
     ]
+    private intermittentRefreshNeededNamespaces = [
+        Protocols, 
+        Samples
+    ]
+    private actionStack: string[] = [];
+    private postReponseActionVerbs = ['Set', 'Organise']
+
     constructor(private injector: Injector) { }
 
+    /**
+     * NgxsPlugin main method implementation. Listen out for certain actions, and if a matching action is found,
+     * dispatch a side effect action setting a flag, which is intended to prompt users to rerun validation.
+     * Secondary function is to listen for certain actions that intermittently don't resolve, and if such an action is handled,
+     * push it to a stack that is consumed by components that will use it to decide whether to render a message prompting the user
+     * to manually refresh the page.
+     * @param state Current NGXS state 
+     * @param action Intercepted action
+     * @param next NgxsNextPluginFn
+     * @returns action
+     */
     handle(state: any, action: any, next: NgxsNextPluginFn): any {
         if (!this.store) this.store = this.injector.get(Store);
         const actionName = action.constructor.type;
@@ -33,11 +52,45 @@ export class LoggingMiddleware implements NgxsPlugin {
             const actionClasses = Object.values(namespace);
             return actionClasses.some(actionClass => action instanceof actionClass);
         });
+        const isInIRNNamespace = this.intermittentRefreshNeededNamespaces.some(ns => {
+            const actionClasses = Object.values(ns);
+            return actionClasses.some(actionClass => action instanceof actionClass);
+        });
 
         if (isInNamespace && !['Get', 'Set', 'Organise'].some(substr => actionName.includes(substr))) {
            this.store.dispatch(new SetValidationRunNeeded(true));
         }
+        if (isInIRNNamespace) {
+            this.isIntermittentRefreshAction(action) ? this.store.dispatch(new IntermittentRefreshActionStack.Sync(this.actionStack)) : null
+            this.isIntermittentRefreshActionResolution(action) ? this.store.dispatch(new IntermittentRefreshActionStack.Sync(this.actionStack)) : null    
+        }
 
         return next(state, action);
     }
+
+    
+    isIntermittentRefreshAction(action: any): boolean {
+        const actionName = action.constructor.type;
+        if (!['Get', 'Set', 'Organise'].some(substr => actionName.includes(substr))) {
+            console.log(actionName)
+            this.actionStack.push(actionName)
+            return true;
+        }
+        return false;
+    }
+
+    isIntermittentRefreshActionResolution(action: any): boolean {
+        const actionName = action.constructor.type;
+        if (this.postReponseActionVerbs.some(substr => actionName.includes(substr))) {
+            const nsRegex = /\[[A-Za-z]+\]/;
+            const ns = actionName.match(nsRegex);
+            let ind = this.actionStack.findIndex(action => action.includes(ns));
+            if (ind > -1) {
+                this.actionStack.splice(ind, 1);
+                return true;
+            }
+        }
+        return false;
+    }
+
 }


### PR DESCRIPTION
Added tooltips to descriptors and factor section headers
implemented middleware service for Ngxs state to detect when whether certain actions had been fulfilled, and if not, prompt the user to refresh
new view for the case where someone tries to access a private study that has an MTBLS accession - tells them it's not yet public, and who (in an abstract sense) to reach out to. If you try and access a private REQ study you will still hit a 404.